### PR TITLE
feat: screen fixes and change released status

### DIFF
--- a/src/components/AutocompleteDriver/AutocompleteDriver.tsx
+++ b/src/components/AutocompleteDriver/AutocompleteDriver.tsx
@@ -53,7 +53,7 @@ export function AutocompleteDriver({
           forcePopupIcon={false}
           options={drivers || []}
           loadingText="Carregando..."
-          defaultValue={{ [keyCode]: field.value ?? null } as Driver}
+          defaultValue={{ [keyCode]: field.value ?? "" } as Driver}
           isOptionEqualToValue={(option: Driver, value: Driver) => option.id === value.id}
           onChange={handleChange}
           noOptionsText={

--- a/src/components/RelaseDriverFilterBar/ReleaseDriverFilterBar.tsx
+++ b/src/components/RelaseDriverFilterBar/ReleaseDriverFilterBar.tsx
@@ -1,10 +1,4 @@
-import {
-  Button,
-  Checkbox,
-  FormControlLabel,
-  Grid,
-  TextField,
-} from "@mui/material";
+import { Button, Grid, MenuItem, Select, TextField } from "@mui/material";
 import { GridSearchIcon } from "@mui/x-data-grid";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
@@ -85,20 +79,20 @@ export function ReleaseDriverFilterBar(
             </Grid>
             <Grid item xs={2}>
               <Controller
-                name={"notReleased"}
+                name={"releaseStatus"}
                 control={control}
                 render={({ field }) => (
-                  <FormControlLabel
-                    componentsProps={{
-                      typography: {
-                        variant: "body2",
-                      },
+                  <Select
+                    {...field}
+                    onChange={(value) => {
+                      console.log(value?.target);
+                      methods.setValue("releaseStatus", value?.target.value);
                     }}
-                    control={
-                      <Checkbox size="small" {...field} checked={field.value} />
-                    }
-                    label={"Não Liberados"}
-                  />
+                  >
+                    <MenuItem value={"all"}>Todos</MenuItem>
+                    <MenuItem value={"notReleased"}>Não liberado</MenuItem>
+                    <MenuItem value={"released"}>Liberado</MenuItem>
+                  </Select>
                 )}
               />
             </Grid>

--- a/src/components/RelaseDriverFilterBar/ReleaseDriverFilterBar.tsx
+++ b/src/components/RelaseDriverFilterBar/ReleaseDriverFilterBar.tsx
@@ -1,4 +1,4 @@
-import { Button, Grid, MenuItem, Select, TextField } from "@mui/material";
+import { Button, Grid, MenuItem, TextField } from "@mui/material";
 import { GridSearchIcon } from "@mui/x-data-grid";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
@@ -82,8 +82,9 @@ export function ReleaseDriverFilterBar(
                 name={"releaseStatus"}
                 control={control}
                 render={({ field }) => (
-                  <Select
+                  <TextField
                     {...field}
+                    select
                     onChange={(value) => {
                       console.log(value?.target);
                       methods.setValue("releaseStatus", value?.target.value);
@@ -92,7 +93,7 @@ export function ReleaseDriverFilterBar(
                     <MenuItem value={"all"}>Todos</MenuItem>
                     <MenuItem value={"notReleased"}>Não liberado</MenuItem>
                     <MenuItem value={"released"}>Liberado</MenuItem>
-                  </Select>
+                  </TextField>
                 )}
               />
             </Grid>

--- a/src/components/RelaseDriverFilterBar/useRealeseDriverFilterBar.ts
+++ b/src/components/RelaseDriverFilterBar/useRealeseDriverFilterBar.ts
@@ -16,7 +16,7 @@ interface FormFields {
   nickName?: string;
   licensePlate?: string;
   fleetCode?: string;
-  notReleased?: boolean;
+  releaseStatus?: string;
 }
 
 const dateOrDayjsSchema = z.custom(
@@ -35,7 +35,7 @@ const schema = z.object({
   nickName: z.string().optional(),
   licensePlate: z.string().optional(),
   fleetCode: z.string().optional(),
-  notReleased: z.boolean().optional(),
+  releaseStatus: z.string().optional(),
 });
 
 export function useReleaseDriverFilterBar() {
@@ -53,11 +53,12 @@ export function useReleaseDriverFilterBar() {
       dtRef: dayjs(params.get("dtRef")).isValid()
         ? dayjs(params.get("dtRef"))
         : dayjs(),
-      notReleased: Boolean(params.get("notReleased")) || true,
+      releaseStatus: params.get("releaseStatus") || "notReleased",
     },
   });
 
   const onSubmit = (data: FormFields) => {
+    console.log(data);
     if (!data?.locOrig.length) {
       methods.setError("locOrig", { message: "*Obrigatório" });
       return;

--- a/src/components/ReleaseDriverDialog/ReleaseDriverDialog.tsx
+++ b/src/components/ReleaseDriverDialog/ReleaseDriverDialog.tsx
@@ -56,6 +56,12 @@ export const ReleaseDriverDialog: FC<ReleaseDriverDialogProps> = ({
       mdfe: data?.mdfe,
       cte: data?.cte,
       obs: data?.obs,
+      presentationDate: data?.presentationDate,
+      issueDate: data?.issueDate,
+      issueResponsible: data?.issueResponsible,
+      palletInvoice: data?.palletInvoice,
+      productInvoice: data?.productInvoice,
+      isReturnLoaded: data?.isReturnLoaded,
     };
 
     try {

--- a/src/components/ReleaseDriverDialog/ReleaseDriverForm/ReleaseDriverForm.tsx
+++ b/src/components/ReleaseDriverDialog/ReleaseDriverForm/ReleaseDriverForm.tsx
@@ -1,4 +1,11 @@
-import { Box, TextField } from "@mui/material";
+import {
+  Box,
+  Checkbox,
+  FormControlLabel,
+  MenuItem,
+  Select,
+  TextField,
+} from "@mui/material";
 import { Controller, useFormContext } from "react-hook-form";
 
 import { AutocompleteDriver } from "@/components/AutocompleteDriver";
@@ -8,6 +15,7 @@ import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import dayjs from "dayjs";
 import "dayjs/locale/pt-br";
 import customParseFormat from "dayjs/plugin/customParseFormat";
+import { DateTimePicker } from "@mui/x-date-pickers";
 
 dayjs.extend(customParseFormat);
 
@@ -206,6 +214,68 @@ export const ReleaseDriverForm = () => {
               }}
             />
           </Box>
+          <Box sx={{ flexBasis: "135px" }}>
+            <Controller
+              name="palletInvoice"
+              control={control}
+              render={({ field }) => {
+                return (
+                  <TextField
+                    label="Invoice do Pallet"
+                    {...field}
+                    type="tel"
+                    value={field.value}
+                    inputProps={{
+                      maxLength: 10,
+                    }}
+                  />
+                );
+              }}
+            />
+          </Box>
+          <Box sx={{ flexBasis: "135px" }}>
+            <Controller
+              name="productInvoice"
+              control={control}
+              render={({ field }) => {
+                return (
+                  <TextField
+                    label="Invoice do produto"
+                    {...field}
+                    type="tel"
+                    value={field.value}
+                    inputProps={{
+                      maxLength: 10,
+                    }}
+                  />
+                );
+              }}
+            />
+          </Box>
+          <Box sx={{ flexBasis: "135px" }}>
+            <Controller
+              name={"isReturnLoaded"}
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  label="Retorno Carregado?"
+                  select
+                  sx={{
+                    width: "100%",
+                  }}
+                  defaultValue={"false"}
+                  {...field}
+                  onChange={(value) => {
+                    console.log(value?.target);
+                    methods.setValue("isReturnLoaded", value?.target.value);
+                  }}
+                >
+                  <MenuItem value={"false"}>Não</MenuItem>
+                  <MenuItem value={"true"}>Sim</MenuItem>
+                </TextField>
+              )}
+            />
+          </Box>
           <Box sx={{ flexBasis: "425px" }}>
             <Controller
               name="obs"
@@ -232,7 +302,66 @@ export const ReleaseDriverForm = () => {
               }}
             />
           </Box>
+
+          <Box sx={{ flexBasis: "190px" }}>
+            <Controller
+              name="presentationDate"
+              control={control}
+              render={({ field }) => {
+                return (
+                  <DateTimePicker
+                    label="Data da Apresentação"
+                    {...field}
+                    value={field.value}
+                  />
+                );
+              }}
+            />
+          </Box>
+          <Box sx={{ flexBasis: "190px" }}>
+            <Controller
+              name="issueDate"
+              control={control}
+              render={({ field }) => {
+                return (
+                  <DateTimePicker
+                    label="Data do Problema"
+                    {...field}
+                    value={field.value}
+                  />
+                );
+              }}
+            />
+          </Box>
+          <Box sx={{ flexBasis: "280px" }}>
+            <Controller
+              name="issueResponsible"
+              control={control}
+              render={({ field }) => {
+                return (
+                  <TextField
+                    label="Responsável pelo problema"
+                    {...field}
+                    sx={{
+                      width: "100%",
+                    }}
+                    type="tel"
+                    value={field.value}
+                    inputProps={{
+                      maxLength: 200,
+                    }}
+                  />
+                );
+              }}
+            />
+          </Box>
         </Box>
+        <Box
+          display="flex"
+          flexDirection="row"
+          gap="10px"
+          flexWrap={"wrap"}
+        ></Box>
       </Box>
       <Box gap="10px" display="flex" flexDirection="column"></Box>
     </LocalizationProvider>

--- a/src/components/ReleaseDriverDialog/ReleaseDriverForm/ReleaseDriverForm.tsx
+++ b/src/components/ReleaseDriverDialog/ReleaseDriverForm/ReleaseDriverForm.tsx
@@ -160,11 +160,13 @@ export const ReleaseDriverForm = () => {
                       },
                     }}
                     label="MDFE"
-                    type="number"
+                    type="tel"
                     {...field}
                     value={field.value}
                     onInput={(e: React.ChangeEvent<HTMLInputElement>) => {
-                      e.target.value = e.target.value.slice(0, 12);
+                      e.target.value = e.target.value
+                        .slice(0, 12)
+                        .replace(/\D/g, "");
                     }}
                     inputProps={{
                       maxLength: 12,
@@ -189,10 +191,12 @@ export const ReleaseDriverForm = () => {
                     }}
                     label="CTE"
                     {...field}
-                    type="number"
+                    type="tel"
                     value={field.value}
                     onInput={(e: React.ChangeEvent<HTMLInputElement>) => {
-                      e.target.value = e.target.value.slice(0, 10);
+                      e.target.value = e.target.value
+                        .slice(0, 10)
+                        .replace(/\D/g, "");
                     }}
                     inputProps={{
                       maxLength: 10,

--- a/src/components/ReleaseDriverDialog/useReleaseDriverDialog.ts
+++ b/src/components/ReleaseDriverDialog/useReleaseDriverDialog.ts
@@ -2,6 +2,7 @@ import { useFetch } from "@/hooks/useFetch";
 import { useHash } from "@/hooks/useHash";
 import { useReleaseDriver } from "@/hooks/useReleaseDriver/useReleaseDriver";
 import { ReleaseDriverInterface } from "@/interfaces/release-driver";
+import dayjs from "dayjs";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 
@@ -17,7 +18,7 @@ export function useReleaseDriverDialog() {
   const loading = isLoading && !error;
 
   const driverAndTruckToRelase = drivers.find(
-    (driver) => driver.dailyTripSectionId === releaseDriverId,
+    (driver) => driver.dailyTripSectionId === releaseDriverId
   );
 
   const methods = useForm();
@@ -28,7 +29,7 @@ export function useReleaseDriverDialog() {
     options?: {
       onSuccess?: () => void;
       onError?: () => void;
-    },
+    }
   ) => {
     return create("/Journey/ReleaseDriverCheck", body, {
       onSuccess: options?.onSuccess,
@@ -46,6 +47,16 @@ export function useReleaseDriverDialog() {
       veiculoPlan: data?.veiculoPlan,
       motoristaLiberado: data?.motoristaLiberado,
       veiculoLiberado: data?.veiculoLiberado,
+      dtCheckList: dayjs().format(),
+      mdfe: data?.mdfe,
+      cte: data?.cte,
+      obs: data?.obs,
+      presentationDate: data?.presentationDate,
+      issueDate: data?.issueDate,
+      issueResponsible: data?.issueResponsible,
+      palletInvoice: data?.palletInvoice,
+      productInvoice: data?.productInvoice,
+      isReturnLoaded: data?.isReturnLoaded,
     };
     return defaultValues;
   };

--- a/src/features/ReleaseDriver/ReleaseDriver.tsx
+++ b/src/features/ReleaseDriver/ReleaseDriver.tsx
@@ -83,7 +83,7 @@ export function ReleaseDriver() {
                 background: "transparent",
                 border: "none",
                 outline: "none",
-                color: "black",
+                color: "#24438f",
                 cursor: "pointer",
               }}
             >
@@ -158,7 +158,7 @@ export function ReleaseDriver() {
       const dtRef = dayjs(params.get("dtRef")).isValid()
         ? dayjs(params.get("dtRef")).format("YYYY-MM-DD")
         : dayjs().format("YYYY-MM-DD");
-      const locOrig = params.get("locOrig") || "";
+      const locOrig = params.get("origemlocOrig") || "";
       if (dtRef && locOrig) {
         const newParams = new URLSearchParams();
         newParams.append("dtRef", dtRef);
@@ -205,7 +205,6 @@ export function ReleaseDriver() {
           }}
         >
           <strong>ORIGEM:</strong> {origem}
-          {hash}
         </Box>
         <Card
           sx={{

--- a/src/features/ReleaseDriver/ReleaseDriver.tsx
+++ b/src/features/ReleaseDriver/ReleaseDriver.tsx
@@ -21,7 +21,7 @@ export function ReleaseDriver() {
     {
       field: "saida",
       headerName: "SAÍDA",
-      width: 150,
+      width: 140,
       valueGetter: (_, data: ReleaseDriverInterface) => {
         return data.saida ? data.saida : "N/A";
       },
@@ -29,7 +29,7 @@ export function ReleaseDriver() {
     {
       field: "entrega",
       headerName: "ENTREGA",
-      width: 150,
+      width: 140,
       valueGetter: (_, data: ReleaseDriverInterface) => {
         return data.entrega ? data.entrega : "N/A";
       },
@@ -46,7 +46,7 @@ export function ReleaseDriver() {
     {
       field: "destino",
       headerName: "DESTINO",
-      width: 150,
+      width: 110,
       valueGetter: (_, data: ReleaseDriverInterface) => {
         return data.destino ? data.destino : "N/A";
       },
@@ -54,7 +54,7 @@ export function ReleaseDriver() {
     {
       field: "motoristaPlan",
       headerName: "MOT.PLAN.",
-      width: 150,
+      width: 140,
       valueGetter: (_, data: ReleaseDriverInterface) => {
         return data.motoristaPlan ? data.motoristaPlan : "N/A";
       },
@@ -62,7 +62,7 @@ export function ReleaseDriver() {
     {
       field: "veiculoPlan",
       headerName: "VEÍCULO PLAN.",
-      width: 150,
+      width: 140,
       valueGetter: (_, data: ReleaseDriverInterface) => {
         return data.veiculoPlan ? data.veiculoPlan : "N/A";
       },
@@ -70,7 +70,7 @@ export function ReleaseDriver() {
     {
       field: "dtCheckList",
       headerName: "CHECK-LIST",
-      width: 70,
+      width: 140,
       renderCell: (params) => {
         if (
           params.row.dtCheckList === null ||
@@ -97,7 +97,7 @@ export function ReleaseDriver() {
     {
       field: "motoristaLiberado",
       headerName: "MOT.REAL.",
-      width: 150,
+      width: 140,
       valueGetter: (_, data: ReleaseDriverInterface) => {
         return data.motoristaLiberado ? data.motoristaLiberado : "N/A";
       },
@@ -113,10 +113,10 @@ export function ReleaseDriver() {
     {
       field: "dtLiberacao",
       headerName: "LIBERAÇÃO",
-      width: 100,
+      width: 140,
       renderCell: (params) => {
         return params.row.dtLiberacao
-          ? dayjs(params.row.dtLiberacao).format("DD/MM/YYYY HH:mm:ss")
+          ? dayjs(params.row.dtLiberacao).format("DD/MM/YYYY HH:mm")
           : "";
       },
     },
@@ -153,7 +153,7 @@ export function ReleaseDriver() {
     if (
       !params.get("dtRef") ||
       !params.get("locOrig") ||
-      !params.get("notReleased")
+      !params.get("releaseStatus")
     ) {
       const dtRef = dayjs(params.get("dtRef")).isValid()
         ? dayjs(params.get("dtRef")).format("YYYY-MM-DD")
@@ -164,8 +164,8 @@ export function ReleaseDriver() {
         newParams.append("dtRef", dtRef);
         newParams.append("locOrig", locOrig);
         newParams.append(
-          "notReleased",
-          params.get("notReleased") === "true" ? "true" : "false",
+          "releaseStatus",
+          params.get("releaseStatus") === "true" ? "true" : "false",
         );
         if (params.get("nickName")) {
           newParams.append("nickName", params.get("nickName") || "");

--- a/src/hooks/useReleaseDriver/useReleaseDriver.ts
+++ b/src/hooks/useReleaseDriver/useReleaseDriver.ts
@@ -15,7 +15,7 @@ export const useReleaseDriver = (options?: SWRConfiguration) => {
     fleetCode: params.get("fleetCode"),
     demand: params.get("demand"),
     locOrig: params.get("locOrig"),
-    notReleased: params.get("notReleased"),
+    releaseStatus: params.get("releaseStatus"),
   };
 
   const getKey = (

--- a/src/interfaces/release-driver.ts
+++ b/src/interfaces/release-driver.ts
@@ -10,6 +10,15 @@ export interface ReleaseDriverInterface {
   dtCheckList?: Date;
   dtLiberacao?: Date;
   dailyTripSectionId: string;
+  mdfe: string;
+  cte: string;
+  obs: string;
+  presentationDate: string;
+  issueDate: string;
+  issueResponsible: string;
+  palletInvoice: string;
+  productInvoice: string;
+  isReturnLoaded: boolean;
 }
 
 export interface ReleaseDriverResponse {


### PR DESCRIPTION
## Atividades

- [x]  FRONT 	2.2 - Coluna Liberação - Aumentar o campo para mostrar a Data + hora (Sem os segundos)
- [x]  FRONT 	2.4 - Trocar a cor do botão Liberado para Azul
- [x]  FRONT 	2.7 - Deixar em branco quando a informação está nula (excluíndo o N/A)
- [x]  API+FR 	2.9 - Ajustar o filtro para trazer as viagens "não liberadas", "liberadas" e "tudo"
    - [x]  Alterado o campo de notReleased para releaseStatus com status: all, released e notReleased. (Eduardo tem que alterar na api)
- [x]  API+FR 	2.10  - Novos campos na tela de liberação
- [x]  Horario de apresentação Real – Tipo Data/hora
- [x]  Horário de emissão de MDF-e – Tipo Data/hora
- [x]  Responsável pela emissão – Tipo Texto
- [x]  Número da nf de pallet – Tipo Texto
- [x]  Numero da NF de Produto – Tipo Texto
- [x]  Caixa para flag – retorno vazio ou carregado.